### PR TITLE
add torch_spmd support to torchtitan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ torchtitan/datasets/**/*.model
 *.log
 error.json
 _remote_module_non_scriptable.py
+
+# torch compile debug related
+torch_compile_debug/*

--- a/torchtitan/config_manager.py
+++ b/torchtitan/config_manager.py
@@ -229,6 +229,14 @@ class JobConfig:
             action="store_true",
             help="Whether to apply loss parallel when sequence parallel is enabled",
         )
+
+        # experimental configs
+        self.parser.add_argument(
+            "--experimental.torch_spmd",
+            default=False,
+            action="store_true",
+            help="Whether to use the experimental torch_spmd style parallelism",
+        )
         self.parser.add_argument(
             "--experimental.pipeline_parallel_degree",
             type=int,

--- a/torchtitan/parallelisms/parallelize_llama.py
+++ b/torchtitan/parallelisms/parallelize_llama.py
@@ -455,6 +455,11 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
     NOTE: The passed-in model preferably should be on meta device. Otherwise,
     the model must fit on GPU or CPU memory.
     """
+    # NOTE(lty): experimental for the PT-D 24 research internship project
+    if job_config.experimental.torch_spmd:
+        return parallelize_llama_torch_spmd(
+            model, world_mesh, parallel_dims, job_config
+        )
 
     if parallel_dims.tp_enabled:
         model = apply_tp(model, world_mesh, parallel_dims, job_config)
@@ -467,5 +472,46 @@ def parallelize_llama(model, world_mesh, parallel_dims, job_config: JobConfig):
 
     if parallel_dims.dp_enabled:
         model = apply_dp(model, world_mesh, parallel_dims, job_config)
+
+    return model
+
+
+# NOTE(lty): experimental for the PT-D 24 research internship project
+def parallelize_llama_torch_spmd(
+    model, world_mesh, parallel_dims, job_config: JobConfig
+):
+    assert not parallel_dims.pp_enabled, "PP not supported by torch_spmd yet"
+    assert not parallel_dims.tp_enabled, "TP not supported by torch_spmd yet"
+
+    ac_config = job_config.activation_checkpoint
+    assert ac_config.mode == "none", "AC not supported by torch_spmd yet"
+
+    if parallel_dims.dp_enabled:
+        dp_mesh = world_mesh["dp"] if world_mesh.ndim > 1 else world_mesh
+
+        from data_parallel import data_parallel, MixedPrecisionPolicy
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_param],
+            reduce_dtype=TORCH_DTYPE_MAP[job_config.training.mixed_precision_reduce],
+        )
+        model = data_parallel(model, dp_mesh, mode="fully_shard", mp_policy=mp_policy)
+
+        logger.info("Applied Simple FSDP to the model")
+
+    enable_compile = job_config.training.compile
+    if enable_compile:
+        if job_config.model.norm_type == "fused_rmsnorm":
+            raise NotImplementedError(
+                "fused_rmsnorm not yet compatible with torch.compile. Please use layernorm or rmsnorm."
+            )
+
+        # compile + SAC needs some flag
+        torch._dynamo.config._experimental_support_context_fn_in_torch_utils_checkpoint = (
+            True
+        )
+
+        logger.info("Compiling with torch.compile")
+        model = torch.compile(model, fullgraph=True)
 
     return model

--- a/train.py
+++ b/train.py
@@ -192,7 +192,10 @@ def main(job_config: JobConfig):
     model_config.max_seq_len = job_config.training.seq_len
 
     logger.info(f"Building {model_name} {job_config.model.flavor} with {model_config}")
-    with torch.device("meta"):
+    # NOTE(lty): the current torch_spmd prototype doesn't compose with meta init
+    # so we init on CPU, apply parallelism, and then move to GPU
+    # with torch.device("meta"):
+    with torch.device("cpu"):
         model = model_cls.from_model_args(model_config)
 
     # apply fp8 linear module swap
@@ -226,16 +229,21 @@ def main(job_config: JobConfig):
         model, world_mesh, parallel_dims, job_config
     )
 
-    init_device = "cpu" if job_config.checkpoint.create_seed_checkpoint else "cuda"
-    model.to_empty(device=init_device)
+    # NOTE(lty): move from CPU to GPU after applying FSDP2/torch_spmd parallelisms
+    # The original code related to meta init is commented out below
+    model.to("cuda")
+
+    # init_device = "cpu" if job_config.checkpoint.create_seed_checkpoint else "cuda"
+    # model.to_empty(device=init_device)
 
     if parallel_dims.pp_enabled:
         pp_schedule = build_pipeline_schedule(job_config, parallel_dims, stage, loss_fn)
-    else:
-        # If PP is enabled, we can't rely on init_weights, because some layers are missing.
-        # In the future, we may make init_weights handle missing layers, but also have to consider RNG seed propagation.
-        # allocate sharded model on GPU and initialize weights via DTensor
-        model.init_weights()
+    # else:
+    #     # If PP is enabled, we can't rely on init_weights, because some layers are missing.
+    #     # In the future, we may make init_weights handle missing layers, but also have to consider RNG seed propagation.
+
+    #     # allocate sharded model on GPU and initialize weights via DTensor
+    #     model.init_weights()
 
     gpu_mem_stats = gpu_memory_monitor.get_peak_stats()
     logger.info(

--- a/train_configs/debug_model.toml
+++ b/train_configs/debug_model.toml
@@ -19,7 +19,7 @@ save_tb_folder = "tb"
 [model]
 name = "llama3"
 flavor = "debugmodel"
-norm_type = "fused_rmsnorm"  # layernorm / np_layernorm / rmsnorm / fused_rmsnorm
+norm_type = "rmsnorm"  # layernorm / np_layernorm / rmsnorm / fused_rmsnorm
 # test tokenizer.model, for debug purpose only
 tokenizer_path = "./test/assets/test_tiktoken.model"
 
@@ -36,11 +36,12 @@ steps = 10
 data_parallel_degree = -1
 tensor_parallel_degree = 1
 fp8_linear = ""
-compile = false
+compile = true
 dataset = "c4_mini"  # supported datasets: c4_mini (45K), c4 (177M)
 
 [experimental]
 pipeline_parallel_degree = 1
+torch_spmd = true
 
 [checkpoint]
 enable_checkpoint = false
@@ -52,5 +53,5 @@ export_dtype = "float32"
 async_mode = "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
 
 [activation_checkpoint]
-mode = 'selective'  # ['none', 'selective', 'full']
+mode = 'none'  # ['none', 'selective', 'full']
 selective_ac_option = '2'  # 'int' = ac every positive int layer or 'op', ac based on ops policy


### PR DESCRIPTION
1. Added a config `--experimental.torch_spmd` to turn on torch_spmd parallelism.
2. Created an if-condition in `parallelize_llama` to apply `parallelize_llama_torch_spmd` based on the added config.
3. Currently `torch_spmd` doesn't work with meta init. So when `torch_spmd` is on, we init the whole model on CPU, apply `torch_spmd` parallelism, and then move the parallelized model to GPU.